### PR TITLE
Add method to get all items in a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 0.6.0
+
+### Added
+
+- `group()` method to `Client` interface for fetching all items in a group.
+- `Item` class representing a single item.
+
+### Changed
+
+- The `Client::get()` method was renamed `value()`.
+
 ## 0.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ namespace Alley\WP\Big_Pit;
 use Alley\WP\Types\Feature;
 
 interface Client extends Feature {
-	public function get( string $key, string $group ): mixed;
+	public function value( string $key, string $group ): mixed;
 
 	public function set( string $key, mixed $value, string $group ): void;
 
@@ -50,7 +50,7 @@ $big_pit = new Big_Pit\Big_Pit();
 $big_pit->boot();
 
 $big_pit->set( $external_id, $api_response, 'movie_reviews' );
-$big_pit->get( $external_id, 'movie_reviews' ); // '{"id":"abcdef12345","title":"The Best Movie Ever","rating":5}'
+$big_pit->value( $external_id, 'movie_reviews' ); // '{"id":"abcdef12345","title":"The Best Movie Ever","rating":5}'
 $big_pit->delete( $external_id, 'movie_reviews' );
 $big_pit->flush_group( 'movie_reviews' );
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ interface Client extends Feature {
 
 	public function delete( string $key, string $group ): void;
 
+	public function group( string $key ): iterable;
+
 	public function flush_group( string $group ): void;
 }
 ```

--- a/src/big-pit/class-big-pit.php
+++ b/src/big-pit/class-big-pit.php
@@ -54,7 +54,7 @@ final class Big_Pit implements Client {
 	 * @param string $group Item group.
 	 * @return mixed|null
 	 */
-	public function get( string $key, string $group ): mixed {
+	public function value( string $key, string $group ): mixed {
 		global $wpdb;
 
 		assert( $wpdb instanceof \wpdb );

--- a/src/big-pit/class-big-speculative-pit.php
+++ b/src/big-pit/class-big-speculative-pit.php
@@ -109,6 +109,16 @@ final class Big_Speculative_Pit implements Client {
 	}
 
 	/**
+	 * Get all values in a group.
+	 *
+	 * @param string $group Item group.
+	 * @return Item[]
+	 */
+	public function group( string $group ): iterable {
+		return $this->origin->group( $group );
+	}
+
+	/**
 	 * Delete all values in a group.
 	 *
 	 * @param string $group Item group.

--- a/src/big-pit/class-big-speculative-pit.php
+++ b/src/big-pit/class-big-speculative-pit.php
@@ -75,14 +75,14 @@ final class Big_Speculative_Pit implements Client {
 	 * @param string $group Item group.
 	 * @return mixed|null
 	 */
-	public function get( string $key, string $group ): mixed {
+	public function value( string $key, string $group ): mixed {
 		$this->fetched_keys[ $group ][] = $key;
 
 		if ( $this->items->has( $key, $group ) ) {
 			return $this->items->get( $key, $group );
 		}
 
-		return $this->origin->get( $key, $group );
+		return $this->origin->value( $key, $group );
 	}
 
 	/**
@@ -159,7 +159,7 @@ final class Big_Speculative_Pit implements Client {
 			return;
 		}
 
-		$saved = $this->origin->get( $this->key(), 'big_speculative_pit' );
+		$saved = $this->origin->value( $this->key(), 'big_speculative_pit' );
 
 		$this->saved_keys = is_array( $saved ) ? $saved : [];
 

--- a/src/big-pit/class-item.php
+++ b/src/big-pit/class-item.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Item class file
+ *
+ * @package wp-big-pit
+ */
+
+namespace Alley\WP\Big_Pit;
+
+/**
+ * A single item retrieved from the DB.
+ */
+final class Item {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $key    Item key.
+	 * @param mixed  $value  Item value.
+	 * @param string $group  Item group.
+	 * @param Client $client Big Pit client.
+	 */
+	public function __construct(
+		private readonly string $key,
+		public readonly mixed $value,
+		private readonly string $group,
+		private readonly Client $client,
+	) {}
+
+	/**
+	 * Delete the item.
+	 */
+	public function delete(): void {
+		$this->client->delete( $this->key, $this->group );
+	}
+}

--- a/src/big-pit/interface-client.php
+++ b/src/big-pit/interface-client.php
@@ -20,7 +20,7 @@ interface Client extends Feature {
 	 * @param string $group Item group.
 	 * @return mixed|null
 	 */
-	public function get( string $key, string $group ): mixed;
+	public function value( string $key, string $group ): mixed;
 
 	/**
 	 * Set a value.

--- a/src/big-pit/interface-client.php
+++ b/src/big-pit/interface-client.php
@@ -40,6 +40,14 @@ interface Client extends Feature {
 	public function delete( string $key, string $group ): void;
 
 	/**
+	 * Get all values in a group.
+	 *
+	 * @param string $group Item group.
+	 * @return Item[]
+	 */
+	public function group( string $group ): iterable;
+
+	/**
 	 * Delete all values in a group.
 	 *
 	 * @param string $group Item group.

--- a/src/simplecache/class-big-pit-adapter.php
+++ b/src/simplecache/class-big-pit-adapter.php
@@ -62,7 +62,7 @@ final class Big_Pit_Adapter implements CacheInterface {
 	 * @return mixed The value of the item from the cache, or $default in case of cache miss.
 	 */
 	public function get( string $key, mixed $default = null ): mixed {
-		$value = $this->pit->get( $key, $this->group );
+		$value = $this->pit->value( $key, $this->group );
 
 		return $value ?? $default;
 	}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,16 +48,16 @@ abstract class TestCase extends TestkitTest_Case {
 		$client->set( $key3, $val3, $grp2 );
 
 		// Get key1, delete it, and assert it's gone.
-		$this->assertSame( $val1, $client->get( $key1, $grp1 ) );
+		$this->assertSame( $val1, $client->value( $key1, $grp1 ) );
 		$client->delete( $key1, $grp1 );
-		$this->assertNull( $client->get( $key1, $grp1 ) );
+		$this->assertNull( $client->value( $key1, $grp1 ) );
 
 		// Get key2, flush group1, and assert it's gone.
-		$this->assertSame( $val2, $client->get( $key2, $grp1 ) );
+		$this->assertSame( $val2, $client->value( $key2, $grp1 ) );
 		$client->flush_group( $grp1 );
-		$this->assertNull( $client->get( $key2, $grp1 ) );
+		$this->assertNull( $client->value( $key2, $grp1 ) );
 
 		// key3 should still be there.
-		$this->assertSame( $val3, $client->get( $key3, $grp2 ) );
+		$this->assertSame( $val3, $client->value( $key3, $grp2 ) );
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,5 +59,21 @@ abstract class TestCase extends TestkitTest_Case {
 
 		// key3 should still be there.
 		$this->assertSame( $val3, $client->value( $key3, $grp2 ) );
+
+		// Put key1 and key2 back in.
+		$client->set( $key1, $val1, $grp1 );
+		$client->set( $key2, $val2, $grp1 );
+
+		// The values in the group should be key1 or key2.
+		foreach ( $client->group( $grp1 ) as $item ) {
+			$this->assertTrue( $item->value === $val1 || $item->value === $val2 );
+
+			// Delete the item.
+			$item->delete();
+		}
+
+		// Assert that the group is empty again.
+		$this->assertNull( $client->value( $key1, $grp1 ) );
+		$this->assertNull( $client->value( $key2, $grp1 ) );
 	}
 }

--- a/tests/Unit/InMemoryCacheTest.php
+++ b/tests/Unit/InMemoryCacheTest.php
@@ -25,38 +25,38 @@ class InMemoryCacheTest extends TestCase {
 
 		// Two fetches of the same key should only result in one query.
 		$num_queries_before = $wpdb->num_queries;
-		$big_pit->get( 'key1', 'group1' );
-		$big_pit->get( 'key1', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
 		$this->assertSame( 1, $wpdb->num_queries - $num_queries_before );
 
 		$big_pit->set( 'key1', 'value1', 'group1' );
 
 		// Value has changed, so there should be another query.
 		$num_queries_before = $wpdb->num_queries;
-		$big_pit->get( 'key1', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
 		$this->assertSame( 1, $wpdb->num_queries - $num_queries_before );
 
 		// Fetching it again should not result in another query.
-		$big_pit->get( 'key1', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
 		$this->assertSame( 1, $wpdb->num_queries - $num_queries_before );
 
 		$big_pit->delete( 'key1', 'group1' );
 
 		// Value has changed, so there should be another query.
 		$num_queries_before = $wpdb->num_queries;
-		$big_pit->get( 'key1', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
 		$this->assertSame( 1, $wpdb->num_queries - $num_queries_before );
 
 		$big_pit->set( 'key1', 'value1', 'group1' );
 		$big_pit->set( 'key2', 'value2', 'group1' );
-		$big_pit->get( 'key1', 'group1' );
-		$big_pit->get( 'key2', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
+		$big_pit->value( 'key2', 'group1' );
 		$big_pit->flush_group( 'group1' );
 
 		// All values have changed, so there should be queries for each value in the group that was set.
 		$num_queries_before = $wpdb->num_queries;
-		$big_pit->get( 'key1', 'group1' );
-		$big_pit->get( 'key2', 'group1' );
+		$big_pit->value( 'key1', 'group1' );
+		$big_pit->value( 'key2', 'group1' );
 		$this->assertSame( 2, $wpdb->num_queries - $num_queries_before );
 	}
 
@@ -67,6 +67,6 @@ class InMemoryCacheTest extends TestCase {
 		$big_pit = new Big_Pit();
 		$big_pit->boot();
 		$big_pit->set( 'key1', (object) [ 'foo' => 'bar' ], 'group1' );
-		$this->assertNotSame( $big_pit->get( 'key1', 'group1' ), $big_pit->get( 'key1', 'group1' ) );
+		$this->assertNotSame( $big_pit->value( 'key1', 'group1' ), $big_pit->value( 'key1', 'group1' ) );
 	}
 }


### PR DESCRIPTION
Also renames `Client::get()` to `::value()`.

Side note: I'm not 100% sold on this implementation, but it makes possible a feature on a client site (https://l.alley.dev/852f8f822b), so I'm giving it a shot in the spirit of a pre-1.0 release.