### PR TITLE
Add Symfony 7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 0.7.0
+
+### Added
+
+- Support for Symfony 7 components.
+
 ## 0.6.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/wp-psr16": "^0.1.0",
     "alleyinteractive/wp-type-extensions": "^2.1",
+    "symfony/clock": "^6.4 || ^7.2",
     "symfony/http-foundation": "^6.4 || ^7.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/wp-psr16": "^0.1.0",
     "alleyinteractive/wp-type-extensions": "^2.1",
-    "symfony/http-foundation": "^6.4"
+    "symfony/http-foundation": "^6.4 || ^7.2"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",


### PR DESCRIPTION
As titled.

Required to allow projects that depend on this package to use Symfony 7 components.